### PR TITLE
Updates helper message about data:privatelink:wait

### DIFF
--- a/src/commands/data/privatelink/create.ts
+++ b/src/commands/data/privatelink/create.ts
@@ -52,6 +52,7 @@ export default class EndpointsCreate extends BaseCommand {
 
     this.log()
     this.log(`The privatelink endpoint is now being provisioned for ${color.cyan(database)}.`)
-    this.log(`Run ${color.cyan('heroku data:privatelink:wait --app APP')} to check the creation process.`)
+    this.log('Run ' + color.cyan('heroku data:privatelink:wait ' + database + ' --app ' + flags.app) +
+             ' to check the creation process.')
   }
 }

--- a/test/commands/data/privatelink/create.test.ts
+++ b/test/commands/data/privatelink/create.test.ts
@@ -32,5 +32,6 @@ describe('data:privatelink:create', () => {
     .command(['data:privatelink:create', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('creates a privatelink endpoint with multiple account ids', ctx => {
       expect(ctx.stderr).to.contain('Creating privatelink endpoint... done')
+      expect(ctx.stdout).to.contain('Run heroku data:privatelink:wait postgres-123 --app myapp to check the creation process.')
     })
 })


### PR DESCRIPTION
After successfully creating a PrivateLink connection, we emit a helper
message for the user to track progress of the PrivateLink creation.
Unfortunately, on apps with multiple addons, this command will fail.

This updates that helper message to include the addon name and app name
to make it easier for the user to copy/paste the message into their CLI
without encountering an error.