### PR TITLE
Replace "whitelist" in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _See code: [src/commands/data/privatelink/index.ts](https://github.com/heroku/he
 
 ## `heroku data:privatelink:access [DATABASE]`
 
-list all accounts for your privatelink endpoint's whitelist
+list all allowed accounts for your privatelink endpoint
 
 ```
 USAGE
@@ -80,7 +80,7 @@ _See code: [src/commands/data/privatelink/access/index.ts](https://github.com/he
 
 ## `heroku data:privatelink:access:add [DATABASE]`
 
-add an account to your privatelink endpoint's whitelist
+add an allowed account to your privatelink endpoint
 
 ```
 USAGE
@@ -105,7 +105,7 @@ _See code: [src/commands/data/privatelink/access/add.ts](https://github.com/hero
 
 ## `heroku data:privatelink:access:remove [DATABASE]`
 
-remove an account from your privatelink endpoint's whitelist
+remove an allowed account from your privatelink endpoint
 
 ```
 USAGE

--- a/src/base.ts
+++ b/src/base.ts
@@ -18,10 +18,10 @@ export default abstract class extends Command {
 }
 
 export interface PrivateLinkDB {
-  apps: {name: string},
-  addon: {name: string},
+  apps: { name: string },
+  addon: { name: string },
   status: string,
   service_name: string,
-  whitelisted_accounts: {arn: string, status: string}[],
-  connections: {endpoint_id: string, owner_arn: string, status: string}[],
+  whitelisted_accounts: { arn: string, status: string }[],
+  connections: { endpoint_id: string, owner_arn: string, status: string }[],
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -22,6 +22,6 @@ export interface PrivateLinkDB {
   addon: { name: string },
   status: string,
   service_name: string,
-  whitelisted_accounts: { arn: string, status: string }[],
+  allowed_accounts: { arn: string, status: string }[],
   connections: { endpoint_id: string, owner_arn: string, status: string }[],
 }

--- a/src/commands/data/privatelink/access/add.ts
+++ b/src/commands/data/privatelink/access/add.ts
@@ -37,10 +37,10 @@ export default class EndpointsAccessAdd extends BaseCommand {
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 
     cli.action.start(`Adding ${accountFormatted}`)
-    await this.shogun.put(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
+    await this.shogun.put(`/private-link/v0/databases/${database}/allowed_accounts`, {
       ...this.shogun.defaults,
       body: {
-        whitelisted_accounts: account_ids
+        allowed_accounts: account_ids
       }
     })
     cli.action.stop()

--- a/src/commands/data/privatelink/access/add.ts
+++ b/src/commands/data/privatelink/access/add.ts
@@ -5,7 +5,7 @@ import BaseCommand from '../../../../base'
 import fetcher from '../../../../lib/fetcher'
 
 export default class EndpointsAccessAdd extends BaseCommand {
-  static description = 'add an account to your privatelink endpoint\'s whitelist'
+  static description = 'add an allowed account to your privatelink endpoint'
   static aliases = ['pg:privatelink:access:add', 'kafka:privatelink:access:add', 'redis:privatelink:access:add']
 
   static args = [
@@ -36,7 +36,7 @@ export default class EndpointsAccessAdd extends BaseCommand {
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 
-    cli.action.start(`Adding ${accountFormatted} to the whitelist`)
+    cli.action.start(`Adding ${accountFormatted}`)
     await this.shogun.put(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
       ...this.shogun.defaults,
       body: {

--- a/src/commands/data/privatelink/access/index.ts
+++ b/src/commands/data/privatelink/access/index.ts
@@ -5,7 +5,7 @@ import BaseCommand, {PrivateLinkDB} from '../../../../base'
 import fetcher from '../../../../lib/fetcher'
 
 export default class EndpointsAccessIndex extends BaseCommand {
-  static description = 'list all accounts for your privatelink endpoint\'s whitelist'
+  static description = 'list all allowed accounts for your privatelink endpoint'
   static aliases = ['pg:privatelink:access', 'kafka:privatelink:access', 'redis:privatelink:access']
 
   static args = [
@@ -36,7 +36,7 @@ export default class EndpointsAccessIndex extends BaseCommand {
         }
       })
     } else {
-      cli.error('There are no whitelisted accounts')
+      cli.error('There are no allowed accounts')
     }
   }
 }

--- a/src/commands/data/privatelink/access/index.ts
+++ b/src/commands/data/privatelink/access/index.ts
@@ -24,10 +24,10 @@ export default class EndpointsAccessIndex extends BaseCommand {
     const {args, flags} = this.parse(EndpointsAccessIndex)
     const database = await fetcher(this.heroku, args.database, flags.app)
 
-    const {body: {whitelisted_accounts}} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
+    const {body: {allowed_accounts}} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 
-    if (whitelisted_accounts.length > 0) {
-      cli.table(whitelisted_accounts, {
+    if (allowed_accounts.length > 0) {
+      cli.table(allowed_accounts, {
         arn: {
           header: 'ARN'
         },

--- a/src/commands/data/privatelink/access/remove.ts
+++ b/src/commands/data/privatelink/access/remove.ts
@@ -5,7 +5,7 @@ import BaseCommand from '../../../../base'
 import fetcher from '../../../../lib/fetcher'
 
 export default class EndpointsAccessRemove extends BaseCommand {
-  static description = 'remove an account from your privatelink endpoint\'s whitelist'
+  static description = 'remove an allowed account from your privatelink endpoint'
   static aliases = ['pg:privatelink:access:remove', 'kafka:privatelink:access:remove', 'redis:privatelink:access:remove']
 
   static args = [
@@ -36,7 +36,7 @@ export default class EndpointsAccessRemove extends BaseCommand {
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 
-    cli.action.start(`Removing ${accountFormatted} from the whitelist`)
+    cli.action.start(`Removing ${accountFormatted}`)
     await this.shogun.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
       ...this.shogun.defaults,
       body: {

--- a/src/commands/data/privatelink/access/remove.ts
+++ b/src/commands/data/privatelink/access/remove.ts
@@ -37,10 +37,10 @@ export default class EndpointsAccessRemove extends BaseCommand {
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 
     cli.action.start(`Removing ${accountFormatted}`)
-    await this.shogun.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
+    await this.shogun.patch(`/private-link/v0/databases/${database}/allowed_accounts`, {
       ...this.shogun.defaults,
       body: {
-        whitelisted_accounts: account_ids
+        allowed_accounts: account_ids
       }
     })
     cli.action.stop()

--- a/src/commands/data/privatelink/create.ts
+++ b/src/commands/data/privatelink/create.ts
@@ -40,7 +40,7 @@ export default class EndpointsCreate extends BaseCommand {
     const {body: res} = await this.shogun.post<PrivateLinkDB>(`/private-link/v0/databases/${database}`, {
       ...this.shogun.defaults,
       body: {
-        whitelisted_accounts: account_ids
+        allowed_accounts: account_ids
       }
     })
     cli.action.stop()

--- a/src/commands/data/privatelink/create.ts
+++ b/src/commands/data/privatelink/create.ts
@@ -53,6 +53,6 @@ export default class EndpointsCreate extends BaseCommand {
     this.log()
     this.log(`The privatelink endpoint is now being provisioned for ${color.cyan(database)}.`)
     this.log('Run ' + color.cyan('heroku data:privatelink:wait ' + database + ' --app ' + flags.app) +
-             ' to check the creation process.')
+      ' to check the creation process.')
   }
 }

--- a/src/commands/data/privatelink/index.ts
+++ b/src/commands/data/privatelink/index.ts
@@ -39,10 +39,10 @@ export default class EndpointsIndex extends BaseCommand {
         'Service Name': res.service_name || 'Provisioning',
       })
 
-      if (res && res.whitelisted_accounts.length > 0) {
+      if (res && res.allowed_accounts.length > 0) {
         this.log()
         cli.styledHeader('Allowed Accounts')
-        cli.table(res.whitelisted_accounts, {
+        cli.table(res.allowed_accounts, {
           arn: {header: 'ARN'},
           status: {}
         })

--- a/src/commands/data/privatelink/index.ts
+++ b/src/commands/data/privatelink/index.ts
@@ -41,7 +41,7 @@ export default class EndpointsIndex extends BaseCommand {
 
       if (res && res.whitelisted_accounts.length > 0) {
         this.log()
-        cli.styledHeader('Whitelisted Accounts')
+        cli.styledHeader('Allowed Accounts')
         cli.table(res.whitelisted_accounts, {
           arn: {header: 'ARN'},
           status: {}

--- a/test/commands/data/privatelink/access/add.test.ts
+++ b/test/commands/data/privatelink/access/add.test.ts
@@ -14,8 +14,8 @@ describe('data:privatelink:access:add', () => {
     .stdout()
     .stderr()
     .command(['data:privatelink:access:add', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
-    .it('adds an account to the whitelist', ctx => {
-      expect(ctx.stderr).to.contain('Adding account to the whitelist... done')
+    .it('adds an allowed account', ctx => {
+      expect(ctx.stderr).to.contain('Adding account... done')
     })
 
   test
@@ -30,7 +30,7 @@ describe('data:privatelink:access:add', () => {
     .stdout()
     .stderr()
     .command(['data:privatelink:access:add', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
-    .it('adds multiple accounts to the whitelist', ctx => {
-      expect(ctx.stderr).to.contain('Adding accounts to the whitelist... done')
+    .it('adds multiple allowed accounts', ctx => {
+      expect(ctx.stderr).to.contain('Adding accounts... done')
     })
 })

--- a/test/commands/data/privatelink/access/add.test.ts
+++ b/test/commands/data/privatelink/access/add.test.ts
@@ -4,7 +4,7 @@ import {expect, test} from '../../../../test'
 describe('data:privatelink:access:add', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
+      .put('/private-link/v0/databases/postgres-123/allowed_accounts', {allowed_accounts: ['123456789012:root']})
       .reply(200, {})
     )
     .nock('https://api.heroku.com', api => api
@@ -20,7 +20,7 @@ describe('data:privatelink:access:add', () => {
 
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
+      .put('/private-link/v0/databases/postgres-123/allowed_accounts', {allowed_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
     )
     .nock('https://api.heroku.com', api => api

--- a/test/commands/data/privatelink/access/index.test.ts
+++ b/test/commands/data/privatelink/access/index.test.ts
@@ -2,7 +2,7 @@ import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
 describe('data:privatelink:access', () => {
-  const privateLinkWhitelistResponse = {
+  const privateLinkAllowlistResponse = {
     app: {name: 'myapp'},
     addon: {name: 'postgres-123'},
     status: 'Operational',
@@ -14,7 +14,7 @@ describe('data:privatelink:access', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
       .get('/private-link/v0/databases/postgres-123')
-      .reply(200, privateLinkWhitelistResponse)
+      .reply(200, privateLinkAllowlistResponse)
     )
     .nock('https://api.heroku.com', api => api
       .post('/actions/addons/resolve')
@@ -23,7 +23,7 @@ describe('data:privatelink:access', () => {
     .stdout()
     .stderr()
     .command(['data:privatelink:access', 'postgres-123', '--app', 'myapp'])
-    .it('shows all accounts in the whitelist', ctx => {
+    .it('shows all allowed accounts', ctx => {
       expect(ctx.stdout).to.contain('ARN                         Status')
       expect(ctx.stdout).to.contain('arn:aws:iam::123456789:root Available')
     })

--- a/test/commands/data/privatelink/access/index.test.ts
+++ b/test/commands/data/privatelink/access/index.test.ts
@@ -8,7 +8,7 @@ describe('data:privatelink:access', () => {
     status: 'Operational',
     service_name: 'com.amazonaws.vpce.testvpc"',
     connections: [],
-    whitelisted_accounts: [{arn: 'arn:aws:iam::123456789:root', status: 'Available'}]
+    allowed_accounts: [{arn: 'arn:aws:iam::123456789:root', status: 'Available'}]
   }
 
   test

--- a/test/commands/data/privatelink/access/remove.test.ts
+++ b/test/commands/data/privatelink/access/remove.test.ts
@@ -14,8 +14,8 @@ describe('data:privatelink:access:remove', () => {
     .stdout()
     .stderr()
     .command(['data:privatelink:access:remove', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
-    .it('removes an account from the whitelist', ctx => {
-      expect(ctx.stderr).to.contain('Removing account from the whitelist... done')
+    .it('removes an allowed account', ctx => {
+      expect(ctx.stderr).to.contain('Removing account... done')
     })
 
   test
@@ -30,7 +30,7 @@ describe('data:privatelink:access:remove', () => {
     .stdout()
     .stderr()
     .command(['data:privatelink:access:remove', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
-    .it('removes multiple accounts from the whitelist', ctx => {
-      expect(ctx.stderr).to.contain('Removing accounts from the whitelist... done')
+    .it('removes multiple allowed accounts', ctx => {
+      expect(ctx.stderr).to.contain('Removing accounts... done')
     })
 })

--- a/test/commands/data/privatelink/access/remove.test.ts
+++ b/test/commands/data/privatelink/access/remove.test.ts
@@ -4,7 +4,7 @@ import {expect, test} from '../../../../test'
 describe('data:privatelink:access:remove', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
+      .patch('/private-link/v0/databases/postgres-123/allowed_accounts', {allowed_accounts: ['123456789012:root']})
       .reply(200, {})
     )
     .nock('https://api.heroku.com', api => api
@@ -20,7 +20,7 @@ describe('data:privatelink:access:remove', () => {
 
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
+      .patch('/private-link/v0/databases/postgres-123/allowed_accounts', {allowed_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
     )
     .nock('https://api.heroku.com', api => api

--- a/test/commands/data/privatelink/create.test.ts
+++ b/test/commands/data/privatelink/create.test.ts
@@ -4,7 +4,7 @@ import {expect, test} from '../../../test'
 describe('data:privatelink:create', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:root']})
+      .post('/private-link/v0/databases/postgres-123', {allowed_accounts: ['123456789012:root']})
       .reply(200, {})
     )
     .nock('https://api.heroku.com', api => api
@@ -20,7 +20,7 @@ describe('data:privatelink:create', () => {
 
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
+      .post('/private-link/v0/databases/postgres-123', {allowed_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
     )
     .nock('https://api.heroku.com', api => api

--- a/test/commands/data/privatelink/index.test.ts
+++ b/test/commands/data/privatelink/index.test.ts
@@ -1,6 +1,8 @@
-import {addonsFetcherResponse,
+import {
+  addonsFetcherResponse,
   privateLinkNewlyCreated,
-  privateLinkWithConnections} from '../../../fixtures'
+  privateLinkWithConnections
+} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
 describe('privatelink', () => {
@@ -16,12 +18,12 @@ describe('privatelink', () => {
     .stdout()
     .stderr()
     .command(['data:privatelink', 'postgres-123', '--app', 'myapp'])
-    .it('shows the status of a privatelink endpoint, inc. whitelist and connections', ctx => {
+    .it('shows the status of a privatelink endpoint, inc. allowed accounts and connections', ctx => {
       expect(ctx.stdout).to.contain('=== privatelink endpoint status for postgres-123')
       expect(ctx.stdout).to.contain('Service Name: com.amazonaws.vpce.testvpc')
       expect(ctx.stdout).to.contain('Status:       Operational')
 
-      expect(ctx.stdout).to.contain('Whitelisted Accounts')
+      expect(ctx.stdout).to.contain('Allowed Accounts')
       expect(ctx.stdout).to.contain('ARN                           Status')
       expect(ctx.stdout).to.contain('arn:aws:iam::12345567890:root Active')
 

--- a/test/commands/data/privatelink/wait.test.ts
+++ b/test/commands/data/privatelink/wait.test.ts
@@ -8,7 +8,7 @@ describe('data:privatelink:wait', () => {
     status: 'Operational',
     service_name: 'com.amazonaws.vpce.testvpc"',
     connections: [],
-    whitelisted_accounts: []
+    allowed_accounts: []
   }
 
   test

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -54,7 +54,7 @@ export const privateLinkNewlyCreated = {
   status: 'Provisioning',
   service_name: 'com.amazonaws.vpce.testvpc',
   connections: [],
-  whitelisted_accounts: []
+  allowed_accounts: []
 }
 
 export const privateLinkOperational = {
@@ -67,7 +67,7 @@ export const privateLinkWithConnections = {
   connections: [
     {endpoint_id: '123456', owner_arn: 'arn:aws:iam::12345567890:root', status: 'Available'}
   ],
-  whitelisted_accounts: [
+  allowed_accounts: [
     {arn: 'arn:aws:iam::12345567890:root', status: 'Active'}
   ]
 }


### PR DESCRIPTION
This replaces "whitelist" with "allowlist" or "allowed" throughout the UI.

Internal references like `whitelisted_accounts` remain for compatibility with existing systems.