### PR TITLE
chore: ignore workflows-repo when linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ export default [
     ignores: [
       './lib',
       '**/*.js',
+      'workflows-repo/**',
     ],
   },
   {


### PR DESCRIPTION
* The Release workflow checks out heroku/npm-release-workflows into ./workflows-repo before running npm run lint. Because eslint . walks the whole tree, it lints the workflow repo's own source and fails with 158 errors (single-quote rules, node: protocol, etc.).
* Add workflows-repo/** to eslint.config.mjs ignores so lint scopes to this package's files only.